### PR TITLE
Dan/fix paths issue and add header default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ features = ["derive"]
 [dependencies.reqwest]
 version = "0.12.9"
 default-features = false
-features = ["rustls-tls"]
+features = ["rustls-tls", "json"]
 
 [dev-dependencies.tokio]
 version = "1.41.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,26 +5,26 @@ homepage = "https://github.com/everapihq/currencyapi-rs"
 repository = "https://github.com/everapihq/currencyapi-rs"
 documentation = "https://currencyapi.com/docs"
 license = "MIT"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]
-thiserror = "1.0.68"
-serde_json = "1.0.132"
+thiserror = "2.0.12"
+serde_json = "1.0.140"
 
 [dependencies.serde]
-version = "1.0.214"
+version = "1.0.219"
 features = ["derive"]
 
 [dependencies.strum]
-version = "0.26.3"
+version = "0.27.1"
 features = ["derive"]
 
 [dependencies.reqwest]
-version = "0.12.9"
+version = "0.12.15"
 default-features = false
 features = ["rustls-tls", "json"]
 
 [dev-dependencies.tokio]
-version = "1.41.0"
+version = "1.44.2"
 features = ["rt", "macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,26 +5,26 @@ homepage = "https://github.com/everapihq/currencyapi-rs"
 repository = "https://github.com/everapihq/currencyapi-rs"
 documentation = "https://currencyapi.com/docs"
 license = "MIT"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]
-thiserror = "1.0.30"
-serde_json = "1.0.72"
+thiserror = "1.0.68"
+serde_json = "1.0.132"
 
 [dependencies.serde]
-version = "1.0.131"
+version = "1.0.214"
 features = ["derive"]
 
 [dependencies.strum]
-version = "0.24"
+version = "0.26.3"
 features = ["derive"]
 
 [dependencies.reqwest]
-version = "0.11.7"
+version = "0.12.9"
 default-features = false
 features = ["rustls-tls"]
 
 [dev-dependencies.tokio]
-version = "1.19.2"
+version = "1.41.0"
 features = ["rt", "macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,22 +9,22 @@ version = "0.1.2"
 edition = "2021"
 
 [dependencies]
-thiserror = "2.0.12"
-serde_json = "1.0.140"
+thiserror = "2.0.14"
+serde_json = "1.0.142"
 
 [dependencies.serde]
 version = "1.0.219"
 features = ["derive"]
 
 [dependencies.strum]
-version = "0.27.1"
+version = "0.27.2"
 features = ["derive"]
 
 [dependencies.reqwest]
-version = "0.12.15"
+version = "0.12.23"
 default-features = false
 features = ["rustls-tls", "json"]
 
 [dev-dependencies.tokio]
-version = "1.44.2"
+version = "1.47.1"
 features = ["rt", "macros"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This crate is under development. Especially the response parsing needs some more
 
 ```toml
 [dependencies]
-currencyapi = "0.1.0"
+currencyapi = "0.1.1"
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Find out more about our endpoints, parameters and response data structure in the
 
 ## License
 
-The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
+The MIT License (MIT). Please see [License File](LICENSE) for more information.
 
 [docs]: https://currencyapi.com/docs
 [currencyapi.com]: https://currencyapi.com

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -43,10 +43,11 @@ impl<'a> Currencyapi {
     pub async fn status(
         &self,
     ) -> Result<models::DetailsResponse, error::CurrencyapiError> {
-        let url = construct_base_url(&self.settings.api_key, Some("status"))?;
+        let url = construct_base_url(Some("status"))?;
         let res_body = self
             .client
             .get(url)
+            .header("apikey", &self.settings.api_key)
             .send()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?
@@ -69,10 +70,11 @@ impl<'a> Currencyapi {
     pub async fn currencies(
         &self,
     ) -> Result<models::DetailsResponse, error::CurrencyapiError> {
-        let url = construct_base_url(&self.settings.api_key, Some("currencies"))?;
+        let url = construct_base_url(Some("currencies"))?;
         let res_body = self
             .client
             .get(url)
+            .header("apikey", &self.settings.api_key)
             .send()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?
@@ -102,13 +104,14 @@ impl<'a> Currencyapi {
         base_currency: &'a str,
         currencies: &'a str,
     ) -> Result<models::DetailsResponse, error::CurrencyapiError> {
-        let mut url = construct_base_url(&self.settings.api_key, Some("latest"))?;
+        let mut url = construct_base_url(Some("latest"))?;
         url.query_pairs_mut()
             .append_pair("base_currency", base_currency)
             .append_pair("currencies", currencies);
         let res_body = self
             .client
             .get(url)
+            .header("apikey", &self.settings.api_key)
             .send()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?
@@ -140,7 +143,7 @@ impl<'a> Currencyapi {
         date: &'a str,
         currencies: &'a str,
     ) -> Result<models::DetailsResponse, error::CurrencyapiError> {
-        let mut url = construct_base_url(&self.settings.api_key, Some("historical"))?;
+        let mut url = construct_base_url(Some("historical"))?;
         url.query_pairs_mut()
             .append_pair("base_currency", base_currency)
             .append_pair("date", date)
@@ -148,6 +151,7 @@ impl<'a> Currencyapi {
         let res_body = self
             .client
             .get(url)
+            .header("apikey", &self.settings.api_key)
             .send()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?
@@ -181,7 +185,7 @@ impl<'a> Currencyapi {
         value: i8,
         currencies: &'a str,
     ) -> Result<models::DetailsResponse, error::CurrencyapiError> {
-        let mut url = construct_base_url(&self.settings.api_key, Some("convert"))?;
+        let mut url = construct_base_url(Some("convert"))?;
         url.query_pairs_mut()
             .append_pair("base_currency", base_currency)
             .append_pair("date", date)
@@ -190,6 +194,7 @@ impl<'a> Currencyapi {
         let res_body = self
             .client
             .get(url)
+            .header("apikey", &self.settings.api_key)
             .send()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?
@@ -225,7 +230,7 @@ impl<'a> Currencyapi {
         currencies: &'a str,
         accuracy: &'a str,
     ) -> Result<models::DetailsResponse, error::CurrencyapiError> {
-        let mut url = construct_base_url(&self.settings.api_key, Some("range"))?;
+        let mut url = construct_base_url(Some("range"))?;
         url.query_pairs_mut()
             .append_pair("base_currency", base_currency)
             .append_pair("datetime_start", datetime_start)
@@ -235,6 +240,7 @@ impl<'a> Currencyapi {
         let res_body = self
             .client
             .get(url)
+            .header("apikey", &self.settings.api_key)
             .send()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -31,10 +31,19 @@ impl<'a> Currencyapi {
         Ok(Self { client, settings })
     }
 
+    /// Fetches the status of the currency API.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<models::DetailsResponse, error::CurrencyapiError>` - A result containing either the details response or a currency API error.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the request fails or if the response cannot be parsed.
     pub async fn status(
         &self,
     ) -> Result<models::DetailsResponse, error::CurrencyapiError> {
-        let mut url = construct_base_url(&self.settings.api_key, Some("status"))?;
+        let url = construct_base_url(&self.settings.api_key, Some("status"))?;
         let res_body = self
             .client
             .get(url)
@@ -48,10 +57,19 @@ impl<'a> Currencyapi {
             .map_err(|_| error::CurrencyapiError::ResponseParsingError { body: res_body })
     }
 
+    /// Fetches the list of available currencies.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<models::DetailsResponse, error::CurrencyapiError>` - A result containing either the details response or a currency API error.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the request fails or if the response cannot be parsed.
     pub async fn currencies(
         &self,
     ) -> Result<models::DetailsResponse, error::CurrencyapiError> {
-        let mut url = construct_base_url(&self.settings.api_key, Some("currencies"))?;
+        let url = construct_base_url(&self.settings.api_key, Some("currencies"))?;
         let res_body = self
             .client
             .get(url)
@@ -65,6 +83,20 @@ impl<'a> Currencyapi {
             .map_err(|_| error::CurrencyapiError::ResponseParsingError { body: res_body })
     }
 
+    /// Fetches the latest currency data for the specified base currency and target currencies.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_currency` - A string slice that holds the base currency code.
+    /// * `currencies` - A string slice that holds the target currencies.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<models::DetailsResponse, error::CurrencyapiError>` - A result containing either the details response or a currency API error.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the request fails or if the response cannot be parsed.
     pub async fn latest(
         &self,
         base_currency: &'a str,
@@ -87,6 +119,21 @@ impl<'a> Currencyapi {
             .map_err(|_| error::CurrencyapiError::ResponseParsingError { body: res_body })
     }
 
+    /// Fetches historical currency data for the specified parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_currency` - A string slice that holds the base currency code.
+    /// * `date` - A string slice that holds the date for the historical data.
+    /// * `currencies` - A string slice that holds the target currencies.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<models::DetailsResponse, error::CurrencyapiError>` - A result containing either the details response or a currency API error.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the request fails or if the response cannot be parsed.
     pub async fn historical(
         &self,
         base_currency: &'a str,
@@ -111,6 +158,22 @@ impl<'a> Currencyapi {
             .map_err(|_| error::CurrencyapiError::ResponseParsingError { body: res_body })
     }
 
+    /// Converts a value from the base currency to the target currencies for the specified date.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_currency` - A string slice that holds the base currency code.
+    /// * `date` - A string slice that holds the date for the conversion.
+    /// * `value` - An integer that holds the value to be converted.
+    /// * `currencies` - A string slice that holds the target currencies.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<models::DetailsResponse, error::CurrencyapiError>` - A result containing either the details response or a currency API error.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the request fails or if the response cannot be parsed.
     pub async fn convert(
         &self,
         base_currency: &'a str,
@@ -137,6 +200,23 @@ impl<'a> Currencyapi {
             .map_err(|_| error::CurrencyapiError::ResponseParsingError { body: res_body })
     }
 
+    /// Fetches the range of currency data for the specified parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_currency` - A string slice that holds the base currency code.
+    /// * `datetime_start` - A string slice that holds the start datetime for the range.
+    /// * `datetime_end` - A string slice that holds the end datetime for the range.
+    /// * `currencies` - A string slice that holds the target currencies.
+    /// * `accuracy` - A string slice that holds the accuracy level.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<models::DetailsResponse, error::CurrencyapiError>` - A result containing either the details response or a currency API error.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the request fails or if the response cannot be parsed.
     pub async fn range(
         &self,
         base_currency: &'a str,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -44,18 +44,17 @@ impl<'a> Currencyapi {
         &self,
     ) -> Result<models::DetailsResponse, error::CurrencyapiError> {
         let url = construct_base_url(Some("status"))?;
-        let res_body = self
+        let res_body: models::DetailsResponse = self
             .client
             .get(url)
             .header("apikey", &self.settings.api_key)
             .send()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?
-            .text()
+            .json()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?;
-        serde_json::from_str::<models::DetailsResponse>(&res_body)
-            .map_err(|_| error::CurrencyapiError::ResponseParsingError { body: res_body })
+        Ok(res_body)
     }
 
     /// Fetches the list of available currencies.
@@ -78,11 +77,10 @@ impl<'a> Currencyapi {
             .send()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?
-            .text()
+            .json()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?;
-        serde_json::from_str::<models::DetailsResponse>(&res_body)
-            .map_err(|_| error::CurrencyapiError::ResponseParsingError { body: res_body })
+        Ok(res_body)
     }
 
     /// Fetches the latest currency data for the specified base currency and target currencies.
@@ -108,18 +106,17 @@ impl<'a> Currencyapi {
         url.query_pairs_mut()
             .append_pair("base_currency", base_currency)
             .append_pair("currencies", currencies);
-        let res_body = self
+        let res_body: models::DetailsResponse = self
             .client
             .get(url)
             .header("apikey", &self.settings.api_key)
             .send()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?
-            .text()
+            .json()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?;
-        serde_json::from_str::<models::DetailsResponse>(&res_body)
-            .map_err(|_| error::CurrencyapiError::ResponseParsingError { body: res_body })
+        Ok(res_body)
     }
 
     /// Fetches historical currency data for the specified parameters.
@@ -155,11 +152,10 @@ impl<'a> Currencyapi {
             .send()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?
-            .text()
+            .json()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?;
-        serde_json::from_str::<models::DetailsResponse>(&res_body)
-            .map_err(|_| error::CurrencyapiError::ResponseParsingError { body: res_body })
+        Ok(res_body)
     }
 
     /// Converts a value from the base currency to the target currencies for the specified date.
@@ -191,18 +187,17 @@ impl<'a> Currencyapi {
             .append_pair("date", date)
             .append_pair("value", &value.to_string())
             .append_pair("currencies", currencies);
-        let res_body = self
+        let res_body: models::DetailsResponse = self
             .client
             .get(url)
             .header("apikey", &self.settings.api_key)
             .send()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?
-            .text()
+            .json()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?;
-        serde_json::from_str::<models::DetailsResponse>(&res_body)
-            .map_err(|_| error::CurrencyapiError::ResponseParsingError { body: res_body })
+        Ok(res_body)
     }
 
     /// Fetches the range of currency data for the specified parameters.
@@ -237,17 +232,16 @@ impl<'a> Currencyapi {
             .append_pair("datetime_end", datetime_end)
             .append_pair("accuracy", accuracy)
             .append_pair("currencies", currencies);
-        let res_body = self
+        let res_body: models::DetailsResponse = self
             .client
             .get(url)
             .header("apikey", &self.settings.api_key)
             .send()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?
-            .text()
+            .json()
             .await
             .map_err(|err| error::CurrencyapiError::RequestError { source: err })?;
-        serde_json::from_str::<models::DetailsResponse>(&res_body)
-            .map_err(|_| error::CurrencyapiError::ResponseParsingError { body: res_body })
+        Ok(res_body)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,8 @@ extern crate thiserror;
 
 pub mod api;
 mod error;
+/// This module contains the data structures used for deserializing
+/// the responses from the currencyapi API.pub mod models;
 pub mod models;
 mod utils;
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,8 +1,11 @@
+use std::collections::HashMap;
+use serde_json::Value;
+
 /// Response of the currencyapi
-#[derive(Debug, Deserialize, Serialize, PartialEq, PartialOrd, Clone)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
 pub struct DetailsResponse {
     /// Data source
-    pub data: String,
+    pub data: HashMap<String, Value>,
     /// Request status
-    pub meta: String,
+    pub meta: Option<HashMap<String, Value>>,
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,7 @@ pub mod baseline {
 
     pub fn construct_client(
         user_agent: Option<&str>,
-        settings: &api::Settings,
+        _: &api::Settings,
     ) -> Result<Client, CurrencyapiError> {
         let mut headers = HeaderMap::new();
         let content_type = HeaderValue::from_str("application/json")?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,7 +26,6 @@ pub mod baseline {
     }
 
     pub fn construct_base_url(
-        api_key: &str,
         with_path: Option<&str>,
     ) -> Result<Url, CurrencyapiError> {
         let mut url = Url::parse(BASE_URL).map_err(|_| CurrencyapiError::UrlConstruction)?;
@@ -35,8 +34,6 @@ pub mod baseline {
             let new_path = format!("{}/{}", url.path().trim_end_matches('/'), trimmed_path);
             url.set_path(&new_path);
         }
-        url.query_pairs_mut().append_pair("apikey", api_key);
-        println!("{:?}", url);
         Ok(url)
     }
 }
@@ -47,15 +44,13 @@ mod baseline_test {
 
     #[test]
     fn should_create_base_url_with_api_key() {
-        let base_url = construct_base_url("123", None).unwrap();
-        assert_eq!(base_url.query(), Some("apikey=123"));
+        let base_url = construct_base_url(None).unwrap();
         assert_eq!(base_url.path(), "/v3/");
     }
 
     #[test]
     fn should_create_base_url_with_api_key_and_path() {
-        let base_url = construct_base_url("123", Some("/test/path")).unwrap();
-        assert_eq!(base_url.query(), Some("apikey=123"));
+        let base_url = construct_base_url(Some("/test/path")).unwrap();
         assert_eq!(base_url.path(), "/v3/test/path");
         println!("{:?}", base_url);
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,7 +52,6 @@ mod baseline_test {
     fn should_create_base_url_with_api_key_and_path() {
         let base_url = construct_base_url(Some("/test/path")).unwrap();
         assert_eq!(base_url.path(), "/v3/test/path");
-        println!("{:?}", base_url);
     }
 
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,10 +30,13 @@ pub mod baseline {
         with_path: Option<&str>,
     ) -> Result<Url, CurrencyapiError> {
         let mut url = Url::parse(BASE_URL).map_err(|_| CurrencyapiError::UrlConstruction)?;
-        url.query_pairs_mut().append_pair("apikey", api_key);
         if let Some(path) = with_path {
-            url.set_path(path);
+            let trimmed_path = path.trim_start_matches('/');
+            let new_path = format!("{}/{}", url.path().trim_end_matches('/'), trimmed_path);
+            url.set_path(&new_path);
         }
+        url.query_pairs_mut().append_pair("apikey", api_key);
+        println!("{:?}", url);
         Ok(url)
     }
 }
@@ -46,5 +49,15 @@ mod baseline_test {
     fn should_create_base_url_with_api_key() {
         let base_url = construct_base_url("123", None).unwrap();
         assert_eq!(base_url.query(), Some("apikey=123"));
+        assert_eq!(base_url.path(), "/v3/");
     }
+
+    #[test]
+    fn should_create_base_url_with_api_key_and_path() {
+        let base_url = construct_base_url("123", Some("/test/path")).unwrap();
+        assert_eq!(base_url.query(), Some("apikey=123"));
+        assert_eq!(base_url.path(), "/v3/test/path");
+        println!("{:?}", base_url);
+    }
+
 }


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the `currencyapi-rs` crate, focusing on updating dependencies, improving API ergonomics, and enhancing response parsing. The most significant changes include a switch to passing API keys via headers (rather than query parameters), updating dependencies for better compatibility and security, and improving the structure and deserialization of API responses.

**API and Response Handling Improvements:**

* Refactored all API methods in `src/api/mod.rs` to pass the API key using the `apikey` HTTP header instead of as a query parameter, and to directly deserialize JSON responses using `.json()` rather than manual string parsing. This simplifies error handling and improves security and standards compliance. [[1]](diffhunk://#diff-4715d1ca31922b72b1d5c42d64759dfa3e247bf3fb4a9066d1c4711e6f8478f5R34-R219) [[2]](diffhunk://#diff-4715d1ca31922b72b1d5c42d64759dfa3e247bf3fb4a9066d1c4711e6f8478f5L148-R245)
* Updated the `DetailsResponse` struct in `src/models/mod.rs` to use `HashMap<String, Value>` for the `data` field and an optional `meta` field, allowing for more flexible and accurate deserialization of API responses.

**Dependency Updates:**

* Updated versions for dependencies in `Cargo.toml`, including `thiserror`, `serde_json`, `serde`, `strum`, `reqwest`, and `tokio` to their latest versions for improved performance and security. Also enabled the `json` feature on `reqwest`.

**Utility and Test Refactorings:**

* Refactored the `construct_base_url` function in `src/utils.rs` to no longer require the API key as a parameter, and improved path handling to be more robust. Updated related tests accordingly. [[1]](diffhunk://#diff-23af5356f6001cd3993cd3c801fb7716ea02d1e504081b9fb569332db6107e80L29-R35) [[2]](diffhunk://#diff-23af5356f6001cd3993cd3c801fb7716ea02d1e504081b9fb569332db6107e80L47-R56)
* Updated `construct_client` to remove the unused `settings` parameter.

**Documentation and Metadata:**

* Updated the `README.md` to reflect the new crate version and fixed the license file reference. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R51)
* Bumped crate version to `0.1.2` in `Cargo.toml`.
* Added a missing documentation comment for the `models` module in `src/lib.rs`.